### PR TITLE
docs: override the host layout guide

### DIFF
--- a/docs/getting-started/create-remote-module.md
+++ b/docs/getting-started/create-remote-module.md
@@ -88,7 +88,7 @@ const federatedConfig = remoteTransformer(config, "remote1");
 export default federatedConfig;
 ```
 
-[!ref target="blank" text="View a full webpack.config.js on Github"](https://github.com/workleap/wl-squide/blob/main/sample/remote-module/webpack.dev.js)
+[!ref icon="mark-github" target="blank" text="View a full webpack.config.js on Github"](https://github.com/workleap/wl-squide/blob/main/sample/remote-module/webpack.dev.js)
 
 ## Try the application :rocket:
 

--- a/docs/guides/override-the-host-layout.md
+++ b/docs/guides/override-the-host-layout.md
@@ -3,3 +3,165 @@ order: 100
 ---
 
 # Override the host layout
+
+Most application pages usually share a **common layout** with at least: a navigation bar, a user profile menu and a main content section. In a [React Router's](https://reactrouter.com/en/main) application, this common layout is what we call a `RootLayout`:
+
+```tsx !#12,17,23,27 App.tsx
+import { useMemo } from "react";
+import { createBrowserRouter, RouterProvider } from "react-router-dom";
+import { useRoutes } from "@squide/react-router";
+import { RootLayout } from "./RootLayout.tsx";
+import { AuthenticationBoundary } from "./AuthenticationBoundary.tsx";
+import { Home } from "./Home.tsx";
+
+export function App() {
+    const routes = useRoutes();
+
+    const router = useMemo(() => {
+        return createBrowserRouter({
+            // Pathless route to declare an authenticated boundary.
+            element: <AuthenticationBoundary />,
+            children: [
+                // Pathless route to declare the root layout.
+                element: <RootLayout />,
+                children: [
+                    {
+                        index: "true",
+                        element: <Home />
+                    },
+                    ...routes
+                ]
+            ]
+        });
+    }, [routes]);
+
+    return (
+        <RouterProvider
+            router={router}
+            fallbackElement={<div>Loading...</div>}
+        />
+    );
+}
+```
+
+```tsx RootLayout.tsx
+import { Suspense } from "react";
+import { Outlet } from "react-router-dom";
+import { useNavigationItems, useRenderedNavigationItems } from "@squide/react-router";
+import { UserMenu } from "./UserMenu.tsx";
+
+export function RootLayout() {
+    const navigationItems = useNavigationItems();
+
+    // To keep things simple, we are omitting the definition of "renderItem" and "renderSection".
+    // For a full example, view: https://workleap.github.io/wl-squide/references/routing/userenderednavigationitems/.
+    const navigationElements = useRenderedNavigationItems(navigationItems, renderItem, renderSection);
+
+    return (
+        <>
+            <div>
+                <nav>{navigationElements}</nav>
+                <UserMenu />
+            </div>
+            <Suspense fallback={<div>Loading...</div>}>
+                <Outlet />
+            </Suspense>
+        </>
+    );
+}
+```
+
+In this example, the `RootLayout` is the default layout for the *home page* and every page (route) registered by a module.
+
+For most pages, this is the behavior expected by the author. However, for pages such as a *login page*, the default `RootLayout` isn't a good fit because a *login page* is not bound to a user session (the user is not even authenticated yet).
+
+Those pages in need of a different layout requires a mecanism to pull out their route declaration at the root of the [React Router's](https://reactrouter.com/en/main) router instance, before the `RootLayout` is declared.
+
+``` !#2
+root
+├── Login page   <---------------- Raise here
+├──── Authentication boundary
+├──────── Root layout
+├───────────  Home page
+```
+
+Package managers supporting workspaces such as [Yarn](https://classic.yarnpkg.com/) and [NPM](https://docs.npmjs.com/cli) call this mecanism "hoisting", which means "raise (something) by means of ropes and pulleys". This is exactly what we are trying to achieve here.
+
+`@squide` has a built-in [useHoistedRoutes](/references/routing/useHoistedRoutes.md) hook capable of raising module routes marked as `hoist` at the root of the routes array, before the `RootLayout` declaration. Thus, an hoisted page will not be wrapped by the `RootLayout` and will have full control over its rendering.
+
+To hoist module pages, first transform the module routes with the [useHoistedRoutes](/references/routing/useHoistedRoutes.md) hook before creating the router instance:
+
+```tsx !#12-26,30,34 App.tsx
+import { useMemo } from "react";
+import { createBrowserRouter, RouterProvider } from "react-router-dom";
+import { useRoutes, useHoistedRoutes, type Route } from "@squide/react-router";
+import { RootLayout } from "./RootLayout.tsx";
+import { AuthenticationBoundary } from "./AuthenticationBoundary.tsx";
+import { Home } from "./Home.tsx";
+
+export function App() {
+    const routes = useRoutes();
+
+    // Non hoisted routes will still be bound to the root layout.
+    const wrapManagedRoutes = useCallback((managedRoutes: Route[]) => {
+        return {
+            element: <AuthenticationBoundary />,
+            children: [
+                element: <RootLayout />,
+                children: [
+                    {
+                        index: "true",
+                        element: <Home />
+                    },
+                    ...managedRoutes
+                ]
+            ]
+        };
+    }, []);
+
+    // Allow hoisted routes hoisted by modules to be rendered at the root of the router rather than 
+    // under the root layout.
+    const hoistedRoutes = useHoistedRoutes(routes, wrapManagedRoutes);
+
+    const router = useMemo(() => {
+        return createBrowserRouter(hoistedRoutes);
+    }, [hoistedRoutes]);
+
+    return (
+        <RouterProvider
+            router={router}
+            fallbackElement={<div>Loading...</div>}
+        />
+    );
+}
+```
+
+Then, mark the pages as hoisted and optionally declare a different layout:
+
+```tsx !#11-12 local-module/src/register.tsx
+import { lazy } from "react";
+import type { ModuleRegisterFunction, Runtime } from "@squide/react-router";
+
+const AnotherLayout = lazy(() => import("./AnotherLayout.tsx"));
+const Login = lazy(() => import("./Login.tsx"));
+
+export function register: ModuleRegisterFunction<Runtime>(runtime) {
+    runtime.registerRoutes([
+        {
+            path: "/login",
+            hoist: true,
+            element: <AnotherLayout />,
+            children: [
+                {
+                    index: true,
+                    element: <Login />
+                }
+            ]
+        }
+    ]);
+}
+```
+
+[!ref For additional options, go to the `useHoistedRoutes` hook reference page](/references/routing/useHoistedRoutes.md)
+
+

--- a/docs/guides/override-the-host-layout.md
+++ b/docs/guides/override-the-host-layout.md
@@ -75,7 +75,7 @@ In this example, the `RootLayout` is the default layout for the *home page* and 
 
 For most pages, this is the behavior expected by the author. However, for pages such as a *login page*, the default `RootLayout` isn't a good fit because a *login page* is not bound to a user session (the user is not even authenticated yet).
 
-Those pages in need of a different layout requires a mecanism to pull out their route declaration at the root of the [React Router's](https://reactrouter.com/en/main) router instance, before the `RootLayout` is declared.
+Those pages in need of a different layout require a mechanism to pull out their route declaration at the root of the [React Router's](https://reactrouter.com/en/main) router instance, before the `RootLayout` is declared.
 
 ``` !#2
 root

--- a/docs/guides/override-the-host-layout.md
+++ b/docs/guides/override-the-host-layout.md
@@ -85,7 +85,7 @@ root
 ├───────────  Home page
 ```
 
-Package managers supporting workspaces such as [Yarn](https://classic.yarnpkg.com/) and [NPM](https://docs.npmjs.com/cli) call this mecanism "hoisting", which means "raise (something) by means of ropes and pulleys". This is exactly what we are trying to achieve here.
+Package managers supporting workspaces such as [Yarn](https://classic.yarnpkg.com/) and [NPM](https://docs.npmjs.com/cli) call this mechanism "hoisting", which means "raise (something) by means of ropes and pulleys". This is exactly what we are trying to achieve here.
 
 `@squide` has a built-in [useHoistedRoutes](/references/routing/useHoistedRoutes.md) hook capable of raising module routes marked as `hoist` at the root of the routes array, before the `RootLayout` declaration. Thus, an hoisted page will not be wrapped by the `RootLayout` and will have full control over its rendering.
 

--- a/docs/guides/override-the-host-layout.md
+++ b/docs/guides/override-the-host-layout.md
@@ -162,6 +162,6 @@ export function register: ModuleRegisterFunction<Runtime>(runtime) {
 }
 ```
 
-[!ref For additional options, go to the `useHoistedRoutes` hook reference page](/references/routing/useHoistedRoutes.md)
+[!ref icon="gear" text="For additional options, go to the `useHoistedRoutes` hook reference page"](/references/routing/useHoistedRoutes.md)
 
 

--- a/docs/references/registration/registerRemoteModules.md
+++ b/docs/references/registration/registerRemoteModules.md
@@ -104,7 +104,7 @@ const federatedConfig = remoteTransformer(
 export default federatedConfig;
 ```
 
-[!ref View the `remoteTransformer` function](/references/webpack/remoteTransformer.md)
+[!ref icon="gear" text="View the `remoteTransformer` function"](/references/webpack/remoteTransformer.md)
 
 ### Url
 

--- a/docs/references/routing/useHoistedRoutes.md
+++ b/docs/references/routing/useHoistedRoutes.md
@@ -100,7 +100,7 @@ export function register: ModuleRegisterFunction<Runtime>(runtime) {
 ### Register a module page with a different layout
 
 !!!info
-A walkthrough is available in the [Override the host layout](/guides/override-the-host-layout.md) guide.
+Detailed information is available in the [Override the host layout](/guides/override-the-host-layout.md) guide.
 !!!
 
 ```tsx !#15,16 host/src/App.tsx

--- a/docs/references/routing/useHoistedRoutes.md
+++ b/docs/references/routing/useHoistedRoutes.md
@@ -36,9 +36,6 @@ import { RootLayout } from "./RootLayout.tsx";
 import { RootErrorBoundary } from "./RootErrorBoundary.tsx";
 
 export function App() {
-    // Re-render the application once all the remotes are registered.
-    // Otherwise, the remotes routes won't be added to the router as the router will be 
-    // rendered before the remote modules registered their routes.
     const isReady = useAreRemotesReady();
 
     const routes = useRoutes();
@@ -46,7 +43,7 @@ export function App() {
     const wrapManagedRoutes = useCallback((managedRoutes: Route[]) => {
         return {
             // Default layout and error boundary.
-            // Fore more information about nested routes, view https://reactrouter.com/en/main/start/tutorial#nested-routes.
+            // Fore more information about React Router's nested routes, view https://reactrouter.com/en/main/start/tutorial#nested-routes.
             element: <RootLayout />,
             errorElement: <RootErrorBoundary />,
             children: [
@@ -55,7 +52,7 @@ export function App() {
         };
     }, []);
 
-    // Allow routes hoisted by modules to be rendered at the root of the router rather than 
+    // Allow hoisted routes to be rendered at the root of the router rather than 
     // under the default layout and error boundary.
     const hoistedRoutes = useHoistedRoutes(routes, wrapManagedRoutes);
 
@@ -101,6 +98,10 @@ export function register: ModuleRegisterFunction<Runtime>(runtime) {
 ```
 
 ### Register a module page with a different layout
+
+!!!info
+A walkthrough is available in the [Override the host layout](/guides/override-the-host-layout.md) guide.
+!!!
 
 ```tsx !#15,16 host/src/App.tsx
 import { useCallback, useMemo } from "react";
@@ -156,8 +157,8 @@ export function register: ModuleRegisterFunction<Runtime>(runtime) {
         {
             path: "/about",
             hoist: true,
-            // Will render the "About" page with using the "RemoteLayout" rather than "RootLayout".
-            // Fore more information about nested routes, view https://reactrouter.com/en/main/start/tutorial#nested-routes.
+            // Will render the "About" page inside the "RemoteLayout" rather than the "RootLayout".
+            // Fore more information about React Router's nested routes, view https://reactrouter.com/en/main/start/tutorial#nested-routes.
             element: <RemoteLayout />,
             children: [
                 {

--- a/docs/references/routing/useHoistedRoutes.md
+++ b/docs/references/routing/useHoistedRoutes.md
@@ -100,7 +100,7 @@ export function register: ModuleRegisterFunction<Runtime>(runtime) {
 ### Register a module page with a different layout
 
 !!!info
-Detailed information is available in the [Override the host layout](/guides/override-the-host-layout.md) guide.
+For a detailed walkthrough, read [the guide](/guides/override-the-host-layout.md) on how to override the host layout.
 !!!
 
 ```tsx !#15,16 host/src/App.tsx

--- a/docs/references/routing/useHoistedRoutes.md
+++ b/docs/references/routing/useHoistedRoutes.md
@@ -158,7 +158,7 @@ export function register: ModuleRegisterFunction<Runtime>(runtime) {
             path: "/about",
             hoist: true,
             // Will render the "About" page inside the "RemoteLayout" rather than the "RootLayout".
-            // Fore more information about React Router's nested routes, view https://reactrouter.com/en/main/start/tutorial#nested-routes.
+            // For more information about React Router's nested routes, view https://reactrouter.com/en/main/start/tutorial#nested-routes.
             element: <RemoteLayout />,
             children: [
                 {

--- a/docs/references/routing/useRenderedNavigationItems.md
+++ b/docs/references/routing/useRenderedNavigationItems.md
@@ -80,9 +80,7 @@ export default function RootLayout() {
 
     return (
         <>
-            <nav>
-                {navigationElements}
-            </nav>
+            <nav>{navigationElements}</nav>
             <Outlet />
         </>
     );

--- a/docs/references/runtime/runtime-class.md
+++ b/docs/references/runtime/runtime-class.md
@@ -75,7 +75,7 @@ runtime.registerRoutes([
 ]);
 ```
 
-[!ref Setup the host application for hoisted routes](/references/routing/useHoistedRoutes.md)
+[!ref icon="gear" text="Setup the host application to accept hoisted routes"](/references/routing/useHoistedRoutes.md)
 
 ### Register navigation items
 
@@ -101,7 +101,7 @@ runtime.registerNavigationItems([
 ]);
 ```
 
-[!ref Setup the host application to render navigation items](/references/routing/useRenderedNavigationItems.md)
+[!ref icon="gear" text="Setup the host application to render navigation items"](/references/routing/useRenderedNavigationItems.md)
 
 ### Register nested navigation items
 

--- a/sample/host/src/App.tsx
+++ b/sample/host/src/App.tsx
@@ -22,7 +22,7 @@ export function App() {
 
     const wrapManagedRoutes = useCallback((managedRoutes: Route[]) => {
         return {
-            // Pathless route to set a root layout and a root error boundary.
+            // Pathless route to declare a root layout and a root error boundary.
             element: <RootLayout />,
             errorElement: <RootErrorBoundary />,
             children: [
@@ -31,15 +31,15 @@ export function App() {
                     element: <Login />
                 },
                 {
-                    // Pathless route to set an authenticated boundary.
+                    // Pathless route to declare an authenticated boundary.
                     element: <AuthenticationBoundary />,
                     children: [
                         {
-                            // Pathless route to set an authenticated layout.
+                            // Pathless route to declare an authenticated layout.
                             element: <AuthenticatedLayout />,
                             children: [
                                 {
-                                    // Pathless route to set an error boundary inside the layout instead of outside.
+                                    // Pathless route to declare an error boundary inside the layout instead of outside.
                                     // It's quite useful to prevent losing the layout when an unmanaged error occurs.
                                     errorElement: <ModuleErrorBoundary />,
                                     children: [


### PR DESCRIPTION
Added a guide explaining how to override the host layout for a module page.